### PR TITLE
Minor tweaks for upload to zesty

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
 ukui-session-manager (1.0.0) zesty; urgency=medium
 
-  * Initial release (LP:#1664256)
+  * Initial release (LP: #1664256)
 
- -- handsome_feng <jianfengli@ubuntukylin.com>  Sun, 12 Feb 2017 15:03:42 +0800
+ -- handsome_feng <jianfengli@ubuntukylin.com>  Sun, 05 Mar 2017 15:03:42 +0800

--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,7 @@ Package: ukui-session-manager
 Architecture: any
 Depends: dbus-x11,
          mate-desktop-common,
-         ubuntukylin-default-settings (>= 1.3.18),
+         ubuntukylin-default-settings (>= 1.3.17),
          upower,
          ${misc:Depends},
          ${shlibs:Depends},


### PR DESCRIPTION
Minor tweaks:
- I lowered the ubuntukylin-default-settings so this will package is installable. You can use raise that dependency again once that version is in Ubuntu.
- I added a space to the LP: # syntax because that's the usual format and it might confuse some tools if the space is missing.
- I set the changelog date closer to today.
- And I uploaded to the zesty new queue.