### PR TITLE
Add missing QFile include directive

### DIFF
--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -21,6 +21,7 @@
 #include <QWidget>
 #include <QDebug>
 #include <QDesktopWidget>
+#include <QFile>
 #include <QTranslator>
 #include <QCommandLineParser>
 #include <QString>


### PR DESCRIPTION
Fixes the following build failure:
```
/build/ukui-session-manager/src/ukui-session-manager-2.0.0/tools/main.cpp: In function ‘int main(int, char**)’:
/build/ukui-session-manager/src/ukui-session-manager-2.0.0/tools/main.cpp:127:9: error: ‘QFile’ was not declared in this scope
  127 |         QFile qss(":/powerwin.qss");
      |         ^~~~~
```